### PR TITLE
Document <maniacode> noconfirmation attribute

### DIFF
--- a/docs/general/mania-codes.md
+++ b/docs/general/mania-codes.md
@@ -18,6 +18,14 @@ A ManiaCode, much like a ManiaLink, is an XML file. Unline ManiaLinks, the root 
 </maniacode>
 ```
 
+### `noconfirmation="1|0"`
+
+This attribute controls if a `Maniacode completed` message is displayed after the ManiaCode runs. A value of `1` disables the message; a value of `0` uses the default behavior of displaying the message.
+
+```xml
+<maniacode noconfirmation="1">
+```
+
 ## Elements
 ### ``show_message``
 This message will be displayed as a dialog after the ManiaCode finished running. If not specified, the game will display `Maniacode completed` instead.


### PR DESCRIPTION
This adds documentation for the `noconfirmation` attribute for `<maniacode>` elements, which allows controlling the "ManiaCode completed" message that appears after it executes.

This shows up in [ManiaPlanet's documentation](https://doc.maniaplanet.com/manialink/maniacode), but TMF is also compatible with this attribute, working as expected.